### PR TITLE
Don't crash when accessing SSLError.reason if it does not exist.

### DIFF
--- a/deluge_client/client.py
+++ b/deluge_client/client.py
@@ -59,12 +59,12 @@ class DelugeRPCClient(object):
         try:
             self._socket.connect((self.host, self.port))
         except ssl.SSLError as e:
-            if e.reason != 'UNSUPPORTED_PROTOCOL' or not hasattr(ssl, 'PROTOCOL_SSLv3'):
+            if getattr(e, 'reason', None) == 'UNSUPPORTED_PROTOCOL' and hasattr(ssl, 'PROTOCOL_SSLv3'):
+                logger.warning('Was unable to ssl handshake, trying to force SSLv3 (insecure)')
+                self._create_socket(ssl_version=ssl.PROTOCOL_SSLv3)
+                self._socket.connect((self.host, self.port))
+            else:
                 raise
-
-            logger.warning('Was unable to ssl handshake, trying to force SSLv3 (insecure)')
-            self._create_socket(ssl_version=ssl.PROTOCOL_SSLv3)
-            self._socket.connect((self.host, self.port))
 
         logger.debug('Connected to Deluge, logging in')
         if self.deluge_version == 2:

--- a/deluge_client/client.py
+++ b/deluge_client/client.py
@@ -59,7 +59,9 @@ class DelugeRPCClient(object):
         try:
             self._socket.connect((self.host, self.port))
         except ssl.SSLError as e:
-            if getattr(e, 'reason', None) == 'UNSUPPORTED_PROTOCOL' and hasattr(ssl, 'PROTOCOL_SSLv3'):
+            # Note: have not verified that we actually get errno 258 for this error
+            if (hasattr(ssl, 'PROTOCOL_SSLv3') and
+                    (getattr(e, 'reason', None) == 'UNSUPPORTED_PROTOCOL' or e.errno == 258)):
                 logger.warning('Was unable to ssl handshake, trying to force SSLv3 (insecure)')
                 self._create_socket(ssl_version=ssl.PROTOCOL_SSLv3)
                 self._socket.connect((self.host, self.port))


### PR DESCRIPTION
This fixes #5. Python < 2.7.9 does not have a `reason` attribute on an `SSLError` exception.

It does not address this note https://github.com/JohnDoee/deluge-client/issues/5#issuecomment-300279957 I think another ticket should be created if there is a problem with timeouts.