### PR TITLE
Allows RPC methods to be called on client object directly

### DIFF
--- a/deluge_client/client.py
+++ b/deluge_client/client.py
@@ -208,3 +208,18 @@ class DelugeRPCClient(object):
                     tried_reconnect = True
                 else:
                     raise
+
+    def __getattr__(self, item):
+        return RPCCaller(self.call, item)
+
+
+class RPCCaller(object):
+    def __init__(self, caller, method=''):
+        self.caller = caller
+        self.method = method
+
+    def __getattr__(self, item):
+        return RPCCaller(self.caller, self.method+'.'+item)
+
+    def __call__(self, *args, **kwargs):
+        return self.caller(self.method, *args, **kwargs)

--- a/deluge_client/tests.py
+++ b/deluge_client/tests.py
@@ -39,3 +39,8 @@ class TestDelugeClient(TestCase):
             self.client.call('core.get_free_space', '1', '2')
         except Exception as e:
             self.assertEqual('deluge_client.client', e.__module__)
+
+    def test_attr_caller(self):
+        self.client.connect()
+        self.assertIsInstance(self.client.core.get_free_space(), int)
+        self.assertIsInstance(self.client.core.get_free_space('/'), int)


### PR DESCRIPTION
Not sure if you are in to this, it allows an alternate method of calling RPC functions:
```python
client.call('core.methodname', arg)
```
can be called instead like
```python
client.core.methodname(arg)
```
I am a little dubious, since we can't validate what's a valid method, and deluge doesn't seem to send back any error with invalid methods, but that's true for the `.call()` format as well.