### PR TITLE
Fix tests on python 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,12 @@ before_script:
   - sleep 5
 language: python
 python:
+  - "3.6"
   - "3.5"
   - "3.4"
-  - "3.3"
   - "2.7"
 script:
-  - nosetests
+  - pytest
 env:
   - DELUGE_VERSION=2
   - DELUGE_VERSION=1

--- a/deluge_client/client.py
+++ b/deluge_client/client.py
@@ -32,6 +32,10 @@ class FailedToReconnectException(Exception):
     pass
 
 
+class RemoteException(Exception):
+    pass
+
+
 class DelugeRPCClient(object):
     timeout = 20
 
@@ -170,7 +174,7 @@ class DelugeRPCClient(object):
                 exception_msg = b', '.join(exception_msg)
             else:
                 exception_type, exception_msg, traceback = data[0]
-            exception = type(str(exception_type.decode('utf-8', 'ignore')), (Exception, ), {})
+            exception = type(str(exception_type.decode('utf-8', 'ignore')), (RemoteException, ), {})
             exception_msg = '%s\n%s' % (exception_msg.decode('utf-8', 'ignore'),
                                           traceback.decode('utf-8', 'ignore'))
             raise exception(exception_msg)

--- a/deluge_client/tests.py
+++ b/deluge_client/tests.py
@@ -5,6 +5,11 @@ from unittest import TestCase
 
 from .client import DelugeRPCClient
 
+
+if sys.version_info > (3,):
+    long = int
+
+
 class TestDelugeClient(TestCase):
     def setUp(self):
         if sys.platform.startswith('win'):
@@ -31,11 +36,11 @@ class TestDelugeClient(TestCase):
     
     def test_call_method(self):
         self.client.connect()
-        self.assertIsInstance(self.client.call('core.get_free_space'), int)
+        self.assertIsInstance(self.client.call('core.get_free_space'), (int, long))
     
     def test_call_method_arguments(self):
         self.client.connect()
-        self.assertIsInstance(self.client.call('core.get_free_space', '/'), int)
+        self.assertIsInstance(self.client.call('core.get_free_space', '/'), (int, long))
     
     def test_call_method_exception(self):
         self.client.connect()
@@ -48,5 +53,5 @@ class TestDelugeClient(TestCase):
 
     def test_attr_caller(self):
         self.client.connect()
-        self.assertIsInstance(self.client.core.get_free_space(), int)
-        self.assertIsInstance(self.client.core.get_free_space('/'), int)
+        self.assertIsInstance(self.client.core.get_free_space(), (int, long))
+        self.assertIsInstance(self.client.core.get_free_space('/'), (int, long))

--- a/deluge_client/tests.py
+++ b/deluge_client/tests.py
@@ -1,57 +1,57 @@
 import os
 import sys
 
-from unittest import TestCase
+import pytest
 
-from .client import DelugeRPCClient
+from .client import DelugeRPCClient, RemoteException
 
 
 if sys.version_info > (3,):
     long = int
 
 
-class TestDelugeClient(TestCase):
-    def setUp(self):
-        if sys.platform.startswith('win'):
-            auth_path = os.path.join(os.getenv('APPDATA'), 'deluge', 'auth')
-        else:
-            auth_path = os.path.expanduser("~/.config/deluge/auth")
-        
-        with open(auth_path, 'rb') as f:
-            filedata = f.read().decode("utf-8").split('\n')[0].split(':')
-        
-        self.username, self.password = filedata[:2]
-        self.ip = '127.0.0.1'
-        self.port = 58846
-        self.client = DelugeRPCClient(self.ip, self.port, self.username, self.password)
-    
-    def tearDown(self):
-        try:
-            self.client.disconnect()
-        except:
-            pass
-    
-    def test_connect(self):
-        self.client.connect()
-    
-    def test_call_method(self):
-        self.client.connect()
-        self.assertIsInstance(self.client.call('core.get_free_space'), (int, long))
-    
-    def test_call_method_arguments(self):
-        self.client.connect()
-        self.assertIsInstance(self.client.call('core.get_free_space', '/'), (int, long))
-    
-    def test_call_method_exception(self):
-        self.client.connect()
-        try:
-            self.client.call('core.get_free_space', '1', '2')
-        except Exception as e:
-            self.assertEqual('deluge_client.client', e.__module__)
-        else:
-            raise Exception('Should have received an error.')
+@pytest.fixture
+def client():
+    if sys.platform.startswith('win'):
+        auth_path = os.path.join(os.getenv('APPDATA'), 'deluge', 'auth')
+    else:
+        auth_path = os.path.expanduser("~/.config/deluge/auth")
 
-    def test_attr_caller(self):
-        self.client.connect()
-        self.assertIsInstance(self.client.core.get_free_space(), (int, long))
-        self.assertIsInstance(self.client.core.get_free_space('/'), (int, long))
+    with open(auth_path, 'rb') as f:
+        filedata = f.read().decode("utf-8").split('\n')[0].split(':')
+
+    username, password = filedata[:2]
+    ip = '127.0.0.1'
+    port = 58846
+    client = DelugeRPCClient(ip, port, username, password)
+    client.connect()
+
+    yield client
+
+    try:
+        client.disconnect()
+    except:
+        pass
+
+
+def test_connect(client):
+    assert client.connected
+
+
+def test_call_method(client):
+    assert isinstance(client.call('core.get_free_space'), (int, long))
+
+
+def test_call_method_arguments(client):
+    assert isinstance(client.call('core.get_free_space', '/'), (int, long))
+
+
+def test_call_method_exception(client):
+    with pytest.raises(RemoteException) as ex_info:
+        client.call('core.get_free_space', '1', '2')
+    assert 'takes at most 2 arguments' in str(ex_info.value)
+
+
+def test_attr_caller(client):
+    assert isinstance(client.core.get_free_space(), (int, long))
+    assert isinstance(client.core.get_free_space('/'), (int, long))

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+python_files = tests.py
+testpaths = deluge_client

--- a/setup.py
+++ b/setup.py
@@ -25,11 +25,10 @@ setup(
     classifiers=[
         'Development Status :: 4 - Beta',
         'License :: OSI Approved :: MIT License',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
 )


### PR DESCRIPTION
The tests were making sure a result was 'int', but on python 2 they might also have been 'long'. This fixes that.