### PR TITLE
Convert tests to pytest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,9 @@ before_script:
   - sleep 5
 language: python
 python:
+  - "3.6"
   - "3.5"
   - "3.4"
-  - "3.3"
   - "2.7"
 script:
   - pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ python:
   - "3.3"
   - "2.7"
 script:
-  - nosetests
+  - pytest
 env:
   - DELUGE_VERSION=2
   - DELUGE_VERSION=1

--- a/deluge_client/client.py
+++ b/deluge_client/client.py
@@ -32,6 +32,10 @@ class FailedToReconnectException(Exception):
     pass
 
 
+class RemoteException(Exception):
+    pass
+
+
 class DelugeRPCClient(object):
     timeout = 20
 
@@ -170,7 +174,7 @@ class DelugeRPCClient(object):
                 exception_msg = b', '.join(exception_msg)
             else:
                 exception_type, exception_msg, traceback = data[0]
-            exception = type(str(exception_type.decode('utf-8', 'ignore')), (Exception, ), {})
+            exception = type(str(exception_type.decode('utf-8', 'ignore')), (RemoteException, ), {})
             exception_msg = '%s\n%s' % (exception_msg.decode('utf-8', 'ignore'),
                                           traceback.decode('utf-8', 'ignore'))
             raise exception(exception_msg)

--- a/deluge_client/tests.py
+++ b/deluge_client/tests.py
@@ -1,52 +1,53 @@
 import os
 import sys
 
-from unittest import TestCase
+import pytest
 
-from .client import DelugeRPCClient
+from .client import DelugeRPCClient, RemoteException
 
-class TestDelugeClient(TestCase):
-    def setUp(self):
-        if sys.platform.startswith('win'):
-            auth_path = os.path.join(os.getenv('APPDATA'), 'deluge', 'auth')
-        else:
-            auth_path = os.path.expanduser("~/.config/deluge/auth")
-        
-        with open(auth_path, 'rb') as f:
-            filedata = f.read().decode("utf-8").split('\n')[0].split(':')
-        
-        self.username, self.password = filedata[:2]
-        self.ip = '127.0.0.1'
-        self.port = 58846
-        self.client = DelugeRPCClient(self.ip, self.port, self.username, self.password)
-    
-    def tearDown(self):
-        try:
-            self.client.disconnect()
-        except:
-            pass
-    
-    def test_connect(self):
-        self.client.connect()
-    
-    def test_call_method(self):
-        self.client.connect()
-        self.assertIsInstance(self.client.call('core.get_free_space'), int)
-    
-    def test_call_method_arguments(self):
-        self.client.connect()
-        self.assertIsInstance(self.client.call('core.get_free_space', '/'), int)
-    
-    def test_call_method_exception(self):
-        self.client.connect()
-        try:
-            self.client.call('core.get_free_space', '1', '2')
-        except Exception as e:
-            self.assertEqual('deluge_client.client', e.__module__)
-        else:
-            raise Exception('Should have received an error.')
 
-    def test_attr_caller(self):
-        self.client.connect()
-        self.assertIsInstance(self.client.core.get_free_space(), int)
-        self.assertIsInstance(self.client.core.get_free_space('/'), int)
+@pytest.fixture
+def client():
+    if sys.platform.startswith('win'):
+        auth_path = os.path.join(os.getenv('APPDATA'), 'deluge', 'auth')
+    else:
+        auth_path = os.path.expanduser("~/.config/deluge/auth")
+
+    with open(auth_path, 'rb') as f:
+        filedata = f.read().decode("utf-8").split('\n')[0].split(':')
+
+    username, password = filedata[:2]
+    ip = '127.0.0.1'
+    port = 58846
+    client = DelugeRPCClient(ip, port, username, password)
+    client.connect()
+
+    yield client
+
+    try:
+        client.disconnect()
+    except:
+        pass
+
+
+def test_connect(client):
+    assert client.connected
+
+
+def test_call_method(client):
+    assert isinstance(client.call('core.get_free_space'), int)
+
+
+def test_call_method_arguments(client):
+    assert isinstance(client.call('core.get_free_space', '/'), int)
+
+
+def test_call_method_exception(client):
+    with pytest.raises(RemoteException) as ex_info:
+        client.call('core.get_free_space', '1', '2')
+    assert 'takes at most 2 arguments' in str(ex_info.value)
+
+
+def test_attr_caller(client):
+    assert isinstance(client.core.get_free_space(), int)
+    assert isinstance(client.core.get_free_space('/'), int)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+python_files = tests.py
+testpaths = deluge_client

--- a/setup.py
+++ b/setup.py
@@ -25,11 +25,10 @@ setup(
     classifiers=[
         'Development Status :: 4 - Beta',
         'License :: OSI Approved :: MIT License',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
 )


### PR DESCRIPTION
Refs #23 
For your consideration, here's how I would do the tests in pytest.
It crept a little bit, and I added a base class for exceptions from the remote deluge host. I think this makes the test nicer, as well as making it better for scripts using the client to catch remote exceptions.