### PR TITLE
Add context manager magic methods

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -30,7 +30,7 @@ for:
         - DELUGE_VERSION: 2
     install:
       - python --version
-      - cmd: appveyor DownloadFile http://download.deluge-torrent.org/2.0/deluge-2.0b1-win32-setup.exe
+      - cmd: appveyor DownloadFile http://download.deluge-torrent.org/archive/2.0/deluge-2.0b1-win32-setup.exe
       - cmd: deluge-2.0b1-win32-setup.exe /S
       - sh: sudo add-apt-repository ppa:deluge-team/develop -y
       - sh: sudo apt-get -qq update

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ _trial_temp
 docs/_build*
 .env*
 .pytest_cache
+.vscode

--- a/deluge_client/client.py
+++ b/deluge_client/client.py
@@ -262,6 +262,14 @@ class DelugeRPCClient(object):
     def __getattr__(self, item):
         return RPCCaller(self.call, item)
 
+    def __enter__(self):
+        """Connect to client while using with statement."""
+        self.connect()
+
+    def __exit__(self, type, value, traceback):
+        """Disconnect from client at end of with statement."""
+        self.disconnect()
+        return self
 
 class RPCCaller(object):
     def __init__(self, caller, method=''):

--- a/deluge_client/tests.py
+++ b/deluge_client/tests.py
@@ -33,6 +33,7 @@ def client_factory(**kw):
 @pytest.fixture
 def client(request):
     client = client_factory(**getattr(request, 'param', {}))
+    client.connect()
     yield client
 
     try:

--- a/deluge_client/tests.py
+++ b/deluge_client/tests.py
@@ -10,7 +10,7 @@ if sys.version_info > (3,):
     long = int
 
 
-def client_factory():
+def client_factory(**kw):
     """Create a disconnected client for test purposes."""
     if sys.platform.startswith('win'):
         auth_path = os.path.join(os.getenv('APPDATA'), 'deluge', 'auth')
@@ -24,15 +24,15 @@ def client_factory():
     ip = '127.0.0.1'
     port = 58846
     kwargs = {'decode_utf8': True}
-    if hasattr(request, 'param'):
-        kwargs.update(request.param)
+    if kw:
+        kwargs.update(kw)        
     client = DelugeRPCClient(ip, port, username, password, **kwargs)
     return client
 
 
 @pytest.fixture
 def client(request):
-    client = client_factory()
+    client = client_factory(**getattr(request, 'param', {}))
     yield client
 
     try:
@@ -69,6 +69,6 @@ def test_attr_caller(client):
     assert isinstance(client.core.get_free_space('/'), (int, long))
 
 
-def test_call_method_context_manager(contextclient):
+def test_call_method_context_manager(client):
     with client_factory() as client:
         assert isinstance(client.call('core.get_free_space'), (int, long))

--- a/deluge_client/tests.py
+++ b/deluge_client/tests.py
@@ -69,6 +69,6 @@ def test_attr_caller(client):
     assert isinstance(client.core.get_free_space('/'), (int, long))
 
 
-def test_call_method_context_manager(client):
+def test_call_method_context_manager():
     with client_factory() as client:
         assert isinstance(client.call('core.get_free_space'), (int, long))


### PR DESCRIPTION
Hi 👋 ! First time contributor here! I added a quick context manager method here and hacked together some tests (though i don't have a deluge server running locally so i'll need the CI to run to check if the tests perform as expected).

This would allow users to connect to deluge via an API like:

```python
with DelugeRPCClient('..') as client:
    # do stuff, connection is opened/closed automagically
```

Whaddya think?