### PR TITLE
Fix context manager - return the client upon enter

### DIFF
--- a/deluge_client/client.py
+++ b/deluge_client/client.py
@@ -265,11 +265,11 @@ class DelugeRPCClient(object):
     def __enter__(self):
         """Connect to client while using with statement."""
         self.connect()
+        return self
 
     def __exit__(self, type, value, traceback):
         """Disconnect from client at end of with statement."""
         self.disconnect()
-        return self
 
 class RPCCaller(object):
     def __init__(self, caller, method=''):


### PR DESCRIPTION
The magic method that should return self is the __enter__ one and not the __exit__ one.
Cheers and thanks for creating this project!