### PR TITLE
Add automatic login for local Deluge instances

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -56,7 +56,7 @@ before_test:
   - ps: "Start-Sleep -s 10"
 
 test_script:
-  - pytest --show-capture=all
+  - pytest -s
 
 on_failure:
   # Print the deluged log file to help debug problems

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -56,7 +56,7 @@ before_test:
   - ps: "Start-Sleep -s 10"
 
 test_script:
-  - pytest
+  - pytest --show-capture
 
 on_failure:
   # Print the deluged log file to help debug problems

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -56,7 +56,7 @@ before_test:
   - ps: "Start-Sleep -s 10"
 
 test_script:
-  - pytest -s
+  - pytest
 
 on_failure:
   # Print the deluged log file to help debug problems

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -56,7 +56,7 @@ before_test:
   - ps: "Start-Sleep -s 10"
 
 test_script:
-  - pytest --show-capture
+  - pytest --show-capture=all
 
 on_failure:
   # Print the deluged log file to help debug problems

--- a/README.rst
+++ b/README.rst
@@ -81,6 +81,8 @@ Idiom usage
     client.connect()
     call_retry(client, 'core.get_torrents_status', {}, ['name'])
     # or if you have local Deluge instance, you can use the local client
+    # LocalDelugeRPCClient accepts the same parameters, but username and password can be omitted
+    from deluge_client import LocalDelugeRPCClient
     localclient = LocalDelugeRPCClient()
     localclient.connect()
 

--- a/README.rst
+++ b/README.rst
@@ -16,18 +16,21 @@ Install
 -------
 
 From GitHub (develop):
-::
+
+.. code-block:: bash
 
     pip install git+https://github.com/JohnDoee/deluge-client.git#develop
 
 From PyPi (stable):
-::
+
+.. code-block:: bash
 
     pip install deluge-client
 
 Usage
 -----
-::
+
+.. code-block:: python
 
     >>> from deluge_client import DelugeRPCClient
 
@@ -42,7 +45,7 @@ Usage
 
 It is also usable as a context manager.
 
-::
+.. code-block:: python
 
     >>> from deluge_client import DelugeRPCClient
 
@@ -52,7 +55,8 @@ It is also usable as a context manager.
 
 
 Idiom to use for automatic reconnect where the daemon might be offline at call time.
-::
+
+.. code-block:: python
 
     import time
 
@@ -68,13 +72,17 @@ Idiom to use for automatic reconnect where the daemon might be offline at call t
                 time.sleep(5)
 
 Idiom usage
-::
+
+.. code-block:: python
 
     client = DelugeRPCClient('127.0.0.1', 58846, 'username', 'password', automatic_reconnect=True)
     # The client has to be online when you start the process,
     # otherwise you must handle that yourself.
     client.connect()
     call_retry(client, 'core.get_torrents_status', {}, ['name'])
+    # or if you have local Deluge instance, you can use the local client
+    localclient = LocalDelugeRPCClient()
+    localclient.connect()
 
 
 List of Deluge RPC commands
@@ -88,9 +96,12 @@ and `core.py <https://github.com/deluge-torrent/deluge/blob/develop/deluge/core/
 The exported commands are decorated with :code:`@export`.
 
 You can also get a list of exported commands by calling the :code:`daemon.get_method_list` method:
-::
+
+.. code-block:: python
 
     client.call('daemon.get_method_list')
+    # or
+    client.daemon.get_method_list()
 
 License
 -------

--- a/deluge_client/__init__.py
+++ b/deluge_client/__init__.py
@@ -1,1 +1,3 @@
-from .client import DelugeRPCClient, FailedToReconnectException
+from .client import (
+    LocalDelugeRPCClient, DelugeRPCClient, FailedToReconnectException
+)

--- a/deluge_client/__init__.py
+++ b/deluge_client/__init__.py
@@ -1,3 +1,3 @@
 from .client import (
-    LocalDelugeRPCClient, DelugeRPCClient, FailedToReconnectException
+    DelugeRPCClient, LocalDelugeRPCClient, FailedToReconnectException
 )

--- a/deluge_client/client.py
+++ b/deluge_client/client.py
@@ -322,10 +322,9 @@ class LocalDelugeRPCClient(DelugeRPCClient):
 
     @_cache_thread_local
     def _get_local_auth(self):
-        auth_path = ''
-        local_username = local_password = ''
-
+        auth_path = local_username = local_password = ''
         os_family = platform.system()
+
         if os_family == 'Windows':
             app_data_path = os.environ.get('APPDATA')
             auth_path = os.path.join(app_data_path, 'deluge', 'auth')
@@ -334,17 +333,18 @@ class LocalDelugeRPCClient(DelugeRPCClient):
             auth_path = os.path.join(config_path, 'auth')
 
         if os.path.exists(auth_path):
-            for line in io.open(auth_path, 'r', encoding='utf-8'):
-                if not line or line.startswith('#'):
-                    continue
+            with io.open(auth_path, 'r', encoding='utf-8') as f:
+                for line in f:
+                    if not line or line.startswith('#'):
+                        continue
 
-                auth_data = line.split(':')
-                if len(auth_data) < 2:
-                    continue
+                    auth_data = line.split(':')
+                    if len(auth_data) < 2:
+                        continue
 
-                username, password = auth_data[:2]
-                if username == 'localclient':
-                    local_username, local_password = username, password
-                    break
+                    username, password = auth_data[:2]
+                    if username == 'localclient':
+                        local_username, local_password = username, password
+                        break
 
         return local_username, local_password

--- a/deluge_client/client.py
+++ b/deluge_client/client.py
@@ -370,6 +370,8 @@ class LocalDelugeRPCClient(DelugeRPCClient):
                 else:
                     continue
 
+                print('---CREDS---')
+                print(username, password, type(username), type(passowrd))
                 if username == u'localclient':
                     local_username, local_password = username, password
 

--- a/deluge_client/client.py
+++ b/deluge_client/client.py
@@ -4,6 +4,7 @@ import ssl
 import struct
 import warnings
 import zlib
+import io
 import os
 import platform
 from functools import wraps
@@ -354,13 +355,13 @@ class LocalDelugeRPCClient(DelugeRPCClient):
 
 
         if os.path.exists(auth_file):
-            for line in open(auth_file, encoding='utf8'):
+            for line in io.open(auth_file, encoding='utf-8'):
                 line = line.strip()
-                if line.startswith('#') or not line:
+                if line.startswith(u'#') or not line:
                     # This is a comment or blank line
                     continue
 
-                lsplit = line.split(':')
+                lsplit = line.split(u':')
 
                 if len(lsplit) == 2:
                     username, password = lsplit
@@ -369,7 +370,7 @@ class LocalDelugeRPCClient(DelugeRPCClient):
                 else:
                     continue
 
-                if username == 'localclient':
+                if username == u'localclient':
                     local_username, local_password = username, password
 
         return local_username, local_password

--- a/deluge_client/client.py
+++ b/deluge_client/client.py
@@ -299,7 +299,7 @@ class LocalDelugeRPCClient(DelugeRPCClient):
         port=58846,
         username='',
         password='',
-        decode_utf8=False,
+        decode_utf8=True,
         automatic_reconnect=True
     ):
         if (
@@ -355,8 +355,9 @@ class LocalDelugeRPCClient(DelugeRPCClient):
 
 
         if os.path.exists(auth_file):
-            for line in io.open(auth_file, encoding='utf-8'):
-                line = line.strip()
+            for line in io.open(auth_file, 'rb', encoding='utf-8'):
+                line = line.decode("utf-8").strip()
+                print('"' + line + '"', type(line))
                 if line.startswith(u'#') or not line:
                     # This is a comment or blank line
                     continue
@@ -370,8 +371,6 @@ class LocalDelugeRPCClient(DelugeRPCClient):
                 else:
                     continue
 
-                print('---CREDS---')
-                print(username, password, type(username), type(passowrd))
                 if username == u'localclient':
                     local_username, local_password = username, password
 

--- a/deluge_client/client.py
+++ b/deluge_client/client.py
@@ -291,6 +291,7 @@ class RPCCaller(object):
 
 
 class LocalDelugeRPCClient(DelugeRPCClient):
+    """Client with auto discovery for the default local credentials"""
     def __init__(
         self,
         host='127.0.0.1',

--- a/deluge_client/client.py
+++ b/deluge_client/client.py
@@ -356,13 +356,11 @@ class LocalDelugeRPCClient(DelugeRPCClient):
 
         if os.path.exists(auth_file):
             for line in io.open(auth_file, 'rb', encoding='utf-8'):
-                line = line.decode("utf-8").strip()
-                print('"' + line + '"', type(line))
-                if line.startswith(u'#') or not line:
+                if line.startswith('#') or not line:
                     # This is a comment or blank line
                     continue
 
-                lsplit = line.split(u':')
+                lsplit = line.split(':')
 
                 if len(lsplit) == 2:
                     username, password = lsplit
@@ -371,7 +369,7 @@ class LocalDelugeRPCClient(DelugeRPCClient):
                 else:
                     continue
 
-                if username == u'localclient':
+                if username == 'localclient':
                     local_username, local_password = username, password
 
         return local_username, local_password

--- a/deluge_client/client.py
+++ b/deluge_client/client.py
@@ -334,7 +334,7 @@ class LocalDelugeRPCClient(DelugeRPCClient):
             auth_path = os.path.join(config_path, 'auth')
 
         if os.path.exists(auth_path):
-            for line in open(auth_path, 'r'):
+            for line in io.open(auth_path, 'r', encoding='utf-8'):
                 if not line or line.startswith('#'):
                     continue
 

--- a/deluge_client/client.py
+++ b/deluge_client/client.py
@@ -335,14 +335,17 @@ class LocalDelugeRPCClient(DelugeRPCClient):
             config_path = os.path.expanduser(DEFAULT_DELUGE_CONFIG_PATH)
             auth_path = os.path.join(config_path, 'auth')
 
+        print('----- ' + auth_path)
         if os.path.exists(auth_path):
             for line in open(auth_path, 'r'):
+                print('----- ' + auth_path)
                 auth_data = line.split(':')
                 if len(auth_data) < 2:
                     continue
 
                 username, password = auth_data[:2]
-                if username == 'localclient':
+                print('----- ', username, type(username))
+                if username in 'localclient':
                     local_username, local_password = username, password
 
         return local_username, local_password

--- a/deluge_client/client.py
+++ b/deluge_client/client.py
@@ -12,9 +12,7 @@ from threading import local as thread_local
 from .rencode import dumps, loads
 
 
-DEFAULT_DELUGE_CONFIG_PATH = '~/.config/deluge/auth'
-HKEY_PATH = \
-    'Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Shell Folders'
+DEFAULT_LINUX_CONFIG_DIR_PATH = '~/.config/deluge'
 RPC_RESPONSE = 1
 RPC_ERROR = 2
 RPC_EVENT = 3
@@ -328,24 +326,25 @@ class LocalDelugeRPCClient(DelugeRPCClient):
         local_username = local_password = ''
 
         os_family = platform.system()
-        if os_family in 'Windows':
+        if os_family == 'Windows':
             app_data_path = os.environ.get('APPDATA')
             auth_path = os.path.join(app_data_path, 'deluge', 'auth')
-        elif os_family in 'Linux':
-            config_path = os.path.expanduser(DEFAULT_DELUGE_CONFIG_PATH)
+        elif os_family == 'Linux':
+            config_path = os.path.expanduser(DEFAULT_LINUX_CONFIG_DIR_PATH)
             auth_path = os.path.join(config_path, 'auth')
 
-        print('----- ' + auth_path)
         if os.path.exists(auth_path):
             for line in open(auth_path, 'r'):
-                print('----- ' + auth_path)
+                if not line or line.startswith('#'):
+                    continue
+
                 auth_data = line.split(':')
                 if len(auth_data) < 2:
                     continue
 
                 username, password = auth_data[:2]
-                print('----- ', username, type(username))
-                if username in 'localclient':
+                if username == 'localclient':
                     local_username, local_password = username, password
+                    break
 
         return local_username, local_password

--- a/deluge_client/client.py
+++ b/deluge_client/client.py
@@ -344,7 +344,7 @@ class LocalDelugeRPCClient(DelugeRPCClient):
             try:
                 from xdg.BaseDirectory import save_config_path
                 config_path = save_config_path('deluge')
-            except (ImportError, OSError):
+            except ImportError:
                 config_path = os.path.expanduser(DEFAULT_DELUGE_CONFIG_PATH)
 
             try:
@@ -354,15 +354,13 @@ class LocalDelugeRPCClient(DelugeRPCClient):
 
 
         if os.path.exists(auth_file):
-            for line in open(auth_file):
-                if line.startswith('#'):
-                    # This is a comment line
-                    continue
+            for line in open(auth_file, encoding='utf8'):
                 line = line.strip()
-                try:
-                    lsplit = line.split(':')
-                except Exception as e:
+                if line.startswith('#') or not line:
+                    # This is a comment or blank line
                     continue
+
+                lsplit = line.split(':')
 
                 if len(lsplit) == 2:
                     username, password = lsplit
@@ -373,6 +371,5 @@ class LocalDelugeRPCClient(DelugeRPCClient):
 
                 if username == 'localclient':
                     local_username, local_password = username, password
-                    break
 
         return local_username, local_password

--- a/deluge_client/tests.py
+++ b/deluge_client/tests.py
@@ -16,7 +16,7 @@ def client_factory(**kw):
         auth_path = os.path.join(os.getenv('APPDATA'), 'deluge', 'auth')
     else:
         auth_path = os.path.expanduser("~/.config/deluge/auth")
-        
+
     with open(auth_path, 'rb') as f:
         filedata = f.read().decode("utf-8").split('\n')[0].split(':')
 

--- a/deluge_client/tests.py
+++ b/deluge_client/tests.py
@@ -21,6 +21,7 @@ def client_factory(**kw):
         filedata = f.read().decode("utf-8").split('\n')[0].split(':')
 
     username, password = filedata[:2]
+    print('---CREDS---\n' + '"' + username + '" "' + password[:2] + password[-2:] + '"')
     ip = '127.0.0.1'
     port = 58846
     kwargs = {'decode_utf8': True}

--- a/deluge_client/tests.py
+++ b/deluge_client/tests.py
@@ -19,7 +19,8 @@ def client_factory(**kw):
 
     with open(auth_path, 'rb') as f:
         filedata = f.read().decode("utf-8").split('\n')[0].split(':')
-
+        print(filedata, authpath)
+        
     username, password = filedata[:2]
     ip = '127.0.0.1'
     port = 58846
@@ -76,16 +77,10 @@ def test_call_method_context_manager():
 
 
 def test_local_client_connect():
-    with client_factory() as client:
-        pass
-
     with LocalDelugeRPCClient() as local_client:
         assert local_client.connected
 
 
 def test_local_client_method():
-    with client_factory() as client:
-        pass
-
     with LocalDelugeRPCClient() as local_client:
             assert isinstance(local_client.call('core.get_free_space'), (int, long))

--- a/deluge_client/tests.py
+++ b/deluge_client/tests.py
@@ -16,6 +16,7 @@ def client_factory(**kw):
         auth_path = os.path.join(os.getenv('APPDATA'), 'deluge', 'auth')
     else:
         auth_path = os.path.expanduser("~/.config/deluge/auth")
+        print(auth_path)
         print(os.listdir('/home'))
         
     with open(auth_path, 'rb') as f:

--- a/deluge_client/tests.py
+++ b/deluge_client/tests.py
@@ -21,7 +21,6 @@ def client_factory(**kw):
         filedata = f.read().decode("utf-8").split('\n')[0].split(':')
 
     username, password = filedata[:2]
-    print('---CREDS---\n' + '"' + username + '" "' + password[:2] + password[-2:] + '"')
     ip = '127.0.0.1'
     port = 58846
     kwargs = {'decode_utf8': True}
@@ -77,10 +76,16 @@ def test_call_method_context_manager():
 
 
 def test_local_client_connect():
-    with LocalDelugeRPCClient() as deluge:
-        assert deluge.connected
+    with client_factory() as client:
+        pass
+
+    with LocalDelugeRPCClient() as local_client:
+        assert local_client.connected
 
 
 def test_local_client_method():
-    with LocalDelugeRPCClient() as deluge:
-        assert isinstance(deluge.call('core.get_free_space'), (int, long))
+    with client_factory() as client:
+        pass
+
+    with LocalDelugeRPCClient() as local_client:
+            assert isinstance(local_client.call('core.get_free_space'), (int, long))

--- a/deluge_client/tests.py
+++ b/deluge_client/tests.py
@@ -16,12 +16,10 @@ def client_factory(**kw):
         auth_path = os.path.join(os.getenv('APPDATA'), 'deluge', 'auth')
     else:
         auth_path = os.path.expanduser("~/.config/deluge/auth")
-        print(auth_path)
-        print(os.listdir('/home'))
         
     with open(auth_path, 'rb') as f:
         filedata = f.read().decode("utf-8").split('\n')[0].split(':')
-        
+
     username, password = filedata[:2]
     ip = '127.0.0.1'
     port = 58846

--- a/deluge_client/tests.py
+++ b/deluge_client/tests.py
@@ -3,7 +3,7 @@ import sys
 
 import pytest
 
-from .client import DelugeRPCClient, RemoteException
+from .client import DelugeRPCClient, LocalDelugeRPCClient, RemoteException
 
 
 if sys.version_info > (3,):
@@ -73,3 +73,13 @@ def test_attr_caller(client):
 def test_call_method_context_manager():
     with client_factory() as client:
         assert isinstance(client.call('core.get_free_space'), (int, long))
+
+
+def test_local_client_connect():
+    with LocalDelugeRPCClient() as deluge:
+        assert deluge.connected
+
+
+def test_local_client_method():
+    with LocalDelugeRPCClient() as deluge:
+        assert isinstance(deluge.call('core.get_free_space'), (int, long))

--- a/deluge_client/tests.py
+++ b/deluge_client/tests.py
@@ -16,10 +16,10 @@ def client_factory(**kw):
         auth_path = os.path.join(os.getenv('APPDATA'), 'deluge', 'auth')
     else:
         auth_path = os.path.expanduser("~/.config/deluge/auth")
-
+        print(os.listdir('/home'))
+        
     with open(auth_path, 'rb') as f:
         filedata = f.read().decode("utf-8").split('\n')[0].split(':')
-        print(filedata, authpath)
         
     username, password = filedata[:2]
     ip = '127.0.0.1'


### PR DESCRIPTION
Encapsulates the logic for automatic login to local Deluge instance into separate LocalDelugeRPCClient class. This will allow easy maintenance/refactoring or removal in the future.
Code was back-ported from [CouchPotato/CouchPotatoServer/tree/master/libs/synchronousdeluge](https://github.com/CouchPotato/CouchPotatoServer/tree/master/libs/synchronousdeluge)
Made some changes: better error handling and support for Python 3.

What do you think?
It is not messing up with the existing code base and can be axed at any point in the future.
I can also add documentation in the README and additional test case if you want?