### PR TITLE
Detect broken connections / make timeout configurable

### DIFF
--- a/deluge_client/client.py
+++ b/deluge_client/client.py
@@ -173,6 +173,9 @@ class DelugeRPCClient(object):
             except ssl.SSLError:
                 raise CallTimeoutException()
 
+            if len(d) == 0:
+                raise ConnectionLostException()
+
             data += d
             if deluge_version == 2:
                 if expected_bytes is None:

--- a/deluge_client/client.py
+++ b/deluge_client/client.py
@@ -48,14 +48,13 @@ class RemoteException(DelugeClientException):
 
 
 class DelugeRPCClient(object):
-    timeout = 20
-
-    def __init__(self, host, port, username, password, decode_utf8=False, automatic_reconnect=True):
+    def __init__(self, host, port, username, password, decode_utf8=False, automatic_reconnect=True, timeout=20):
         self.host = host
         self.port = port
         self.username = username
         self.password = password
         self.deluge_version = None
+        self.timeout = timeout
         # This is only applicable if deluge_version is 2
         self.deluge_protocol_version = None
 


### PR DESCRIPTION
Hi! 👋 

I was trying to use the `deluge` integration of Home Assistant which uses this egg. I noticed that the deluge device in Home Assistant stayed unreachable after the deluge server was restarted. This happened because a broken connection was not detected and thus never reset.

-------------------------------------------

Detect closed connections in `_receive_response`

When the connection to the deluge server was lost (the server was
restarted or shut down), `_receive_response` was stuck in a infinite
loop before. Since `recv` never returns any data the function never broke
out of the while loop. Raising a `ConnectionLostException` ensures the
retry logic can work as expected.

-------------------------------------------
Make the socket timeout configurable

